### PR TITLE
Add translations for Brazilian Portuguese (app, fastlane, ...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Credits
 - @srccrow for the Italian translations.
 - @inkhorn for the Portuguese translations.
 - @jontaix for Portuguese translations.
+- @lucasmz for Brazilian Portuguese translations.
 - @q1011 for the Russian translations.
 - Oswald van Ginkel for the Afrikaans translations.
 - huuhaa for the Finnish translations.

--- a/app/src/main/res/values-pt-rBR/arrays.xml
+++ b/app/src/main/res/values-pt-rBR/arrays.xml
@@ -6,6 +6,7 @@
         <item>• @srccrow: Traduções em Italiano</item>
         <item>• @inkhorn: Traduções em Português</item>
         <item>• @jontaix: Traduções em Português</item>
+        <item>• @lucasmz: Traduções em Português Brasileiro</item>
         <item>• @q1011: Traduções em Russo</item>
         <item>• Oswald van Ginkel: Traduções em Africâner</item>>
         <item>• huuhaa: Traduções em Finlandês</item>

--- a/app/src/main/res/values-pt-rBR/arrays.xml
+++ b/app/src/main/res/values-pt-rBR/arrays.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="fullCredits">
+        <item>• Petra Mirelli: Traduções em Alemão/Espanhol/Francês/Italiano, banner do app, e modificações variadas</item>
+        <item>• Jean-Luc Tibaux: Traduções em Francês</item>
+        <item>• @srccrow: Traduções em Italiano</item>
+        <item>• @inkhorn: Traduções em Português</item>
+        <item>• @jontaix: Traduções em Português</item>
+        <item>• @q1011: Traduções em Russo</item>
+        <item>• Oswald van Ginkel: Traduções em Africâner</item>>
+        <item>• huuhaa: Traduções em Finlandês</item>
+        <item>• Marcin Mikołajczak: Traduções em Polonês</item>
+        <item>• @Manuel-Senpai: Traduções em Espanhol</item>
+        <item>• @Balthazar1234: Traduções em Alemão</item>
+        <item>• @Sdarfeesh: Traduções em Chinês Simplificado</item>
+        <item>• @cardpuncher: Traduções em Francês/Turco</item>
+        <item>• Tommaso Fonda: Traduções em Italiano</item>
+        <item>• Dimitris Vagiakakos: Traduções em Grego</item>
+        <item>• @gallegonovato: Traduções em Espanhol</item>
+        <item>• @Fjuro: Traduções em Checo</item>
+        <item>• ClamAV by Cisco: Bancos de dados de assinaturas</item>
+        <item>• ESET: Bancos de dados de assinaturas</item>
+        <item>• Nex (@botherder): Bancos de dados de assinaturas</item>
+        <item>• Amnesty International: Bancos de dados de assinaturas</item>
+        <item>• Echap: Bancos de dados de assinaturas</item>
+        <item>• MalwareBazaar: Bancos de dados de assinaturas</item>
+        <item>• VirusShare: Bancos de dados de assinaturas</item>
+        <item>• RecursiveFileObserver.java: Daniel Gultsch, ownCloud Inc., Bartek Przybylski</item>
+        <item>• GPGDetachedSignatureVerifier.java: Federico Fissore, Arduino LLC</item>
+        <item>• Google: ícone do app</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name" translatable="false">Hypatia</string>
+    <string name="app_copyright">Direitos Autorais 2017-2024 Divested Computing Group</string>
+    <string name="app_license">Licença: GPL-3.0</string>
+    <string name="app_version">Versão: %s</string>
+    <string name="app_db_type_clamav">Movido à assinaturas de estilo ClamAV</string>
+
+    <string name="lblOnionRoutingToggle">Baixar via Tor</string>
+    <string name="lblOnionRoutingEnabledHint">Baixando via Tor, isto pode demorar um pouco…</string>
+    <string name="lblOnionRoutingNotInstalled">O Orbot não está instalado!</string>
+    <string name="lblUpdateDatabase">Atualizar bancos de dados</string>
+    <string name="lblDatabaseServer">Substituir o servidor da database</string>
+    <string name="lblFullCredits">Créditos</string>
+    <string name="lblScanSystem">Escanear /system</string>
+    <string name="lblScanApps">Escanear APKs dos apps</string>
+    <string name="lblScanInternal">Escanear o armazenamento interno</string>
+    <string name="lblScanExternal">Escanear armazenamento externo</string>
+    <string name="lblNotificationMalwareDetectionTitle">Detecção de Malware</string>
+    <string name="lblNotificationMalwareDetectionDescription">Usado para alertar quando malware é detectado</string>
+    <string name="lblNotificationRealtimeTitle">Scanner em tempo real</string>
+    <string name="lblNotificationRealtimeDescription">Usado para mostrar o contador de arquivos escaneados e manter o serviço de segundo plano</string>
+    <string name="lblNotificationRealtimeText">Malware conhecido será detectado em tempo real</string>
+    <string name="lblNotificationRealtimeStopped">Hypatia: O escaneamento em tempo real parou</string>
+    <string name="lblNotificationRealtimeDetection">Malware detectado:</string>
+    <string name="lblRealtimeScannerToggle">Escanear em tempo real</string>
+    <string name="lblReset">Redefinir</string>
+    <string name="lblOverride">Substituir</string>
+
+    <string name="main_database_updating">Atualizando %s banco(s) de dados…</string>
+    <string name="main_database_override">Usando o servidor %s</string>
+    <string name="main_database_download_success">Baixado com sucesso</string>
+    <string name="main_database_download_error">Arquivo não foi baixado, código de resposta %s</string>
+    <string name="main_no_database_available">Nenhum banco de dados disponível, o scan não será feito…</string>
+    <string name="main_database_released_on">Lançado em %s</string>
+    <string name="main_database_not_changed">Arquivo não mudou</string>
+    <string name="main_database_not_modified_since">desde %s</string>
+    <string name="main_database_download_error_logcat">Falha ao baixar, verifique o logcat</string>
+
+    <string name="main_starting_scan">Começando o scan…</string>
+    <string name="main_cancelling_scan">Cancelando o scan…</string>
+    <string name="main_files_pending_scan">%s arquivos faltam ser escaneados</string>
+    <string name="main_database_loading">Carregando banco de dados…</string>
+    <string name="main_database_loaded">O banco de dados foi carregado com %s assinaturas</string>
+    <string name="main_hashing_files">Fazendo hash dos arquivos…</string>
+    <string name="main_hashing_done">Hashes calculadas para todos os arquivos</string>
+    <string name="main_hash_scan_done">Foi verificado %s hashes contra os bancos de dados de assinaturas</string>
+    <string name="main_scanning_done">O scan foi completado em %s segundos @ %sMB/s!</string>
+    <string name="main_files_scanned_count">%s arquivos escaneados</string>
+    <string name="scan_control">Controle de Scan</string>
+    <string name="lblScanRunning">Pulando a ação, um scan está em execução!</string>
+    <string name="lblSigningKey">Chave de assinatura do banco de dados</string>
+    <string name="lblNoNetwork">Nenhuma rede conectada!</string>
+    <string name="self_test_result_success">A autoverificação foi feita com sucesso.</string>
+    <string name="self_test_result_failure">A autoverificação falhou!</string>
+    <string name="lblDatabaseLoading">Pulando a ação, o banco de dados está carregando!</string>
+    <string name="lblDatabasesUpdated">Todos os bancos de dados foram atualizados!</string>
+    <string name="lookupVT">Consultar</string>
+    <string name="deleteFile">Excluir</string>
+    <string name="deleted">Excluído!</string>
+    <string name="ignoreDetection">Ignorar</string>
+    <string name="detections_none">Nenhuma correspondência foi encontrada :)</string>
+    <string name="detections_found">Foram encontradas correspondências! :(</string>
+    <string name="confirm_lookup_title">Confirmar consulta</string>
+    <string name="confirm_lookup_summary">Você tem certeza que deseja abrir VirusTotal.com em seu navegador web com a hash seguinte?</string>
+    <string name="confirm_delete_title">Confirmar exclusão</string>
+    <string name="confirm_delete_summary">Você tem certeza que deseja excluir o arquivo seguinte?</string>
+    <string name="delete_failed">Falha ao excluir!</string>
+    <string name="ignored">Ignorado!</string>
+    <string name="uninstallApp">Desinstalar</string>
+    <string name="lblSelfTest">Escrever arquivos de autoverificação</string>
+    <string name="lblExtendedDatabaseToggle">Banco de dados extendido</string>
+    <string name="confirm_extended_title">Ativar o banco de dados extendido?</string>
+    <string name="confirm_extended_summary">[EXPERIMENTAL]\nIsto ativará a detecção de ~40 milhões de assinaturas adicionais.\nIsto precisará de um download de ~125MB, irá fazer com que a inicialização demore mais de 2 minutos, aumentará o uso de RAM do app, e aumentará a taxa de falsos positivos.\nEste banco de dados atualiza somente trimestralmente.</string>
+    <string name="confirm_update_title">Confirmar download</string>
+    <string name="confirm_update_summary">Você parece estar em uma conexão medida. Você tem certeza que deseja atualizar os bancos de dados?\nIsso pode precisar de %s megabytes de dados.</string>
+    <string name="lblUpdateRunning">Pulando a ação, uma atualização está em execução!</string>
+    <string name="lblWroteTestFiles">Arquivos de autoverificação foram escritos!</string>
+</resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -6,6 +6,7 @@
         <item>• @srccrow: Italian Translations</item>
         <item>• @inkhorn: Portuguese Translations</item>
         <item>• @jontaix: Portuguese Translations</item>
+        <item>• @lucasmz: Brazilian Portuguese Translations</item>
         <item>• @q1011: Russian Translations</item>
         <item>• Oswald van Ginkel: Afrikaans Translations</item>>
         <item>• huuhaa: Finnish Translations</item>

--- a/fastlane/metadata/android/pt-BR/full_description.txt
+++ b/fastlane/metadata/android/pt-BR/full_description.txt
@@ -1,0 +1,15 @@
+<p>Hypatia é o primeiro escaneador de malware FOSS para Android. É movido a bancos de dados de assinaturas estilo ClamAV.</p>
+
+<b>Funções</b>
+<ul>
+<li>Quase zero impacto no uso da bateria: você não notará nenhum impacto na bateria</li>
+<li>Extremamente rápido: consegue escanear arquivos pequenos (1MB) em 20ms, e até arquivos grandes (40MB) em 1000ms.</li>
+<li>Uso eficiente da memória: com os bancos de dados padrão ativados, usa menos de 120MB.</li>
+<li>Scan periódico: permitindo a seleção de /system, armazenamento interno, externo, e de apps instalados</li>
+<li>Scanner em tempo real: consegue detectar malware em tempo real em escrita/renomeneio no armazenamento interno</li>
+<li>Completamente offline: A internet é usada somente para baixar os bancos de dados de assinaturas, seus arquivos nunca (nunca mesmo) sairem do seu dispositivo</li>
+<li>Persistência: reiniciará automaticamente no boot/atualização</li>
+<li>Pouco código: Chegando à menos de 1000 sloc, consegue ser analisado por alguém com uma experiência básica de programação</li>
+<li>Dependências mínimas: o app só usa bibliotecas quando necessário</li>
+<li>Os bancos de dados de assinaturas podem ser ativados/desativados à demanda do usuário</li>
+</ul>

--- a/fastlane/metadata/android/pt-BR/short_description.txt
+++ b/fastlane/metadata/android/pt-BR/short_description.txt
@@ -1,0 +1,1 @@
+Um escaneador de malware em tempo real

--- a/fastlane/metadata/android/pt-BR/title.txt
+++ b/fastlane/metadata/android/pt-BR/title.txt
@@ -1,0 +1,1 @@
+Hypatia


### PR DESCRIPTION
Trying to cover everything, or at least most things; whatever's useful.

Could change:
* How scan/scanning/scanner is translated (PT seems to have been translated as "analyse" but it sounds a bit wrong; especially when she consider "Scanner" and a few other things)
* `` Powered (PT translated it to "produced" which seems wrong)
* Translate changelogs, decided not to, as that'd require constant maintenance anyway; I'd be fine doing it with Weblate but opening a PR for everything doesn't make much sense.
* Add translated screenshots, similarly to how French I believe seems to have done, would have to compile the app, prob won't do?
* Add translation for the readme, unsure how that works exactly (it seems rarely read? like github doesn't deal with these properly, not sure about lab.)